### PR TITLE
Optimize insert speed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- More efficient insert operation by not serializing a vector of keys for the whole node.
+  Instead, keys are treated like values and the B-Tree nodes only store references to them.
+- **Backward incompatible**: The maximum order of a B-Tree (as per its configuration) is now
+  84. This is necessary, so a node block always fits inside a memory block. You can configure
+  a smaller size, but with 84 the memory page is utilized fully.
+
+### Fixed
+
+- The block cache could grow indefinitely.
+
 ## [0.1.0] - 2022-02-10
 
 Initial release

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ serde = "1"
 serde_derive = "1"
 bincode = "1.3"
 linked-hash-map = "0.5"
+binary-layout = "2.1"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/benches/btree.rs
+++ b/benches/btree.rs
@@ -32,6 +32,33 @@ fn benchmark(c: &mut Criterion) {
         })
     });
 
+    c.bench_function("insert byte vector", |b| {
+        // Create an index with 10.000 random entries
+        let n_entries = 10_000;
+
+        let config = BtreeConfig::default().max_key_size(16).max_value_size(64);
+
+        let mut btree: BtreeIndex<Vec<u8>, Vec<u8>> =
+            BtreeIndex::with_capacity(config, n_entries).unwrap();
+
+        // Insert the strings
+        for _ in 0..n_entries {
+            btree
+                .insert(fake::vec![u8; 4..16], fake::vec![u8; 32..64])
+                .unwrap();
+        }
+
+        // Generate and insert a known key/value
+        let search_key = fake::vec![u8; 4..16];
+        let search_value = fake::vec![u8; 32..64];
+
+        b.iter(|| {
+            btree
+                .insert(search_key.clone(), search_value.clone())
+                .unwrap();
+        })
+    });
+
     c.bench_function("search existing string", |b| {
         // Create an index with 10.000 random entries
         let n_entries = 10_000;

--- a/fuzz/fuzz_targets/integer_insert.rs
+++ b/fuzz/fuzz_targets/integer_insert.rs
@@ -5,7 +5,7 @@ use std::collections::BTreeMap;
 use transient_btree_index::{BtreeConfig, BtreeIndex, Error};
 
 fuzz_target!(|data: (Vec<(u32, u32)>, u8)| {
-    let order = data.1.max(2);
+    let order = data.1.max(2).min(84);
     let mut m = BTreeMap::default();
     let mut fixture =
         BtreeIndex::with_capacity(BtreeConfig::default().order(order), 1024).unwrap();

--- a/fuzz/fuzz_targets/string_insert.rs
+++ b/fuzz/fuzz_targets/string_insert.rs
@@ -4,7 +4,7 @@ use std::collections::BTreeMap;
 use transient_btree_index::{BtreeConfig, BtreeIndex, Error};
 
 fuzz_target!(|data: (Vec<(String, String)>, u8)| {
-    let order = data.1.max(2);
+    let order = data.1.max(2).min(84);
     let mut m = BTreeMap::default();
     let mut fixture = BtreeIndex::with_capacity(BtreeConfig::default().order(order), 1024).unwrap();
 

--- a/src/btree.rs
+++ b/src/btree.rs
@@ -165,11 +165,8 @@ where
         let root_number_of_keys = self.nodes.number_of_keys(self.root_id).unwrap_or(0);
         if root_number_of_keys == (2 * self.order) - 1 {
             // Create a new root node, because the current will become full
-            let new_root_id = self.nodes.allocate_new_node()?;
-
-            self.nodes.set_child_node(new_root_id, 0, self.root_id)?;
-
-            self.split_child(new_root_id, 0)?;
+            let new_root_id = self.nodes.split_root_node(self.root_id, self.order)?;
+         
             let existing = self.insert_nonfull(new_root_id, &key, value)?;
             self.root_id = new_root_id;
             Ok(existing)
@@ -281,7 +278,7 @@ where
                     let child_id = self.nodes.get_child_node(node_id, i)?;
                     // If the child is full, we need to split it
                     if self.nodes.number_of_keys(node_id)? == (2 * self.order) - 1 {
-                        let (left, right) = self.split_child(node_id, i)?;
+                        let (left, right) = self.nodes.split_child(node_id, i, self.order)?;
                         let node_key = self.nodes.get_key(node_id, i)?;
                         if key == node_key.as_ref() {
                             // Key already exists and was added to the parent node, replace the payload
@@ -307,13 +304,6 @@ where
                 }
             }
         }
-    }
-
-    fn split_child(&mut self, parent_node_id: u64, child_idx: usize) -> Result<(u64, u64)> {
-        let (existing_node, new_node_id) =
-            self.nodes
-                .split_child(parent_node_id, child_idx, self.order)?;
-        Ok((existing_node, new_node_id))
     }
 }
 

--- a/src/btree.rs
+++ b/src/btree.rs
@@ -57,8 +57,8 @@ impl Default for BtreeConfig {
 impl BtreeConfig {
     /// Set the estimated maximum size in bytes for each key.
     ///
-    /// Keys can be larger than this, but if this happens too often inside a BTree node
-    /// the block might need to be re-allocated, which causes memory fragmentation on the disk
+    /// Keys can be larger than this, but if this happens too often the block for the key 
+    /// might need to be re-allocated, which causes memory fragmentation on the disk
     /// and some main memory overhead for remembering the re-allocated block IDs.
     pub fn max_key_size(mut self, est_max_key_size: usize) -> Self {
         self.est_max_key_size = est_max_key_size;
@@ -66,6 +66,10 @@ impl BtreeConfig {
     }
 
     /// Set the estimated maximum size in bytes for each values.
+    /// 
+    /// Values can be larger than this, but if this happens too often the block for the value 
+    /// might need to be re-allocated, which causes memory fragmentation on the disk
+    /// and some main memory overhead for remembering the re-allocated block IDs.
     pub fn max_value_size(mut self, est_max_value_size: usize) -> Self {
         self.est_max_value_size = est_max_value_size;
         self
@@ -73,8 +77,10 @@ impl BtreeConfig {
 
     /// Sets the order of the tree, which determines how many elements a single node can store.
     ///
-    /// A B-tree is balanced so the number of keys of a node is between the order and the order times two.
-    /// The order must be at least 2 for this implementation.
+    /// A B-tree is balanced, so the number of keys of a node is between the order and the order times two. 
+    /// The order must be at least 2 and at most 84 for this implementation, and 
+    /// it is guaranteed that the internal structure for a node always fits inside a memory page. 
+    /// The default is to use the maximum number of keys, so the memory page is utilized as much as possible.
     pub fn order(mut self, order: u8) -> Self {
         self.order = order as usize;
         self

--- a/src/btree.rs
+++ b/src/btree.rs
@@ -234,9 +234,12 @@ where
     fn search(&self, node_id: u64, key: &K) -> Result<Option<(u64, usize)>> {
         let mut i = 0;
         let number_of_keys = self.nodes.number_of_keys(node_id)?;
-        let node_key = self.nodes.get_key(node_id, i)?;
+        let mut node_key = self.nodes.get_key(node_id, i)?;
         while i < number_of_keys && key > node_key.as_ref() {
             i += 1;
+            if i < number_of_keys {
+                node_key = self.nodes.get_key(node_id, i)?;
+            }
         }
         if i < number_of_keys && key == node_key.as_ref() {
             Ok(Some((node_id, i)))
@@ -269,7 +272,7 @@ where
 
                     // Make space for the new key by moving the other items to the right
                     let number_of_node_keys = self.nodes.number_of_keys(node_id)?;
-                    for i in ((i+1)..=number_of_node_keys).rev() {
+                    for i in ((i + 1)..=number_of_node_keys).rev() {
                         self.nodes.set_key(
                             node_id,
                             i,

--- a/src/btree.rs
+++ b/src/btree.rs
@@ -1,169 +1,18 @@
 use std::{
     marker::PhantomData,
     ops::{Bound, RangeBounds},
-    rc::Rc,
-    sync::Arc,
 };
 
 use crate::{
     error::Result,
-    file::{page_aligned_capacity, BlockHeader, TemporaryBlockFile},
+    file::{BlockHeader, TemporaryBlockFile},
     Error,
 };
 use serde::{de::DeserializeOwned, Serialize};
 
-use self::node::NodeFile;
+use self::node::{NodeFile, SearchResult, StackEntry};
 
 mod node;
-
-#[derive(serde_derive::Deserialize, serde_derive::Serialize, Clone)]
-struct NodeBlock<K> {
-    id: usize,
-    keys: Vec<K>,
-    payload: Vec<usize>,
-    child_nodes: Vec<usize>,
-}
-
-fn find_first_candidate<K>(node: Rc<NodeBlock<K>>, start_bound: Bound<&K>) -> StackEntry<K>
-where
-    K: Ord + Clone,
-{
-    match start_bound {
-        Bound::Included(key) => {
-            let key_pos = node.keys.binary_search_by(|e| e.cmp(key));
-            match &key_pos {
-                // Key was found, start at this position
-                Ok(i) => StackEntry::Key { node, idx: *i },
-                // Key not found, but key would be inserted at i, so the next child or key could contain the key
-                Err(i) => {
-                    if node.is_leaf() {
-                        // When searching for for example for 5 in a leaf [2,4,8], i would be 3 and we need to
-                        // start our search at the third key.
-                        // If the search range is after the largest key (e.g. 10 for the previous example),
-                        // the binary search will return the length of the vector as insertion position,
-                        // effectivly generating an invalid candidate which needs to be filterred later
-                        StackEntry::Key { node, idx: *i }
-                    } else {
-                        StackEntry::Child {
-                            parent: node,
-                            idx: *i,
-                        }
-                    }
-                }
-            }
-        }
-        Bound::Excluded(key) => {
-            let key_pos = node.keys.binary_search_by(|e| e.cmp(key));
-            match &key_pos {
-                // Key was found, start at child or key after the key
-                Ok(i) => {
-                    if node.is_leaf() {
-                        StackEntry::Key { node, idx: *i + 1 }
-                    } else {
-                        StackEntry::Child {
-                            parent: node,
-                            idx: *i + 1,
-                        }
-                    }
-                }
-                // Key not found, but key would be inserted at i, so the previous child could contain the key
-                // E.g. when searching for 5 in [c0, k0=2, c1, k1=4, c2, k2=8, c3 ], i would be 2 and we need to
-                // start our search a c2 which is before this key.
-                Err(i) => {
-                    if node.is_leaf() {
-                        StackEntry::Key { node, idx: *i }
-                    } else {
-                        StackEntry::Child {
-                            parent: node,
-                            idx: *i,
-                        }
-                    }
-                }
-            }
-        }
-        Bound::Unbounded => {
-            if node.is_leaf() {
-                // Return the first key
-                StackEntry::Key { node, idx: 0 }
-            } else {
-                // Return the first child
-                StackEntry::Child {
-                    parent: node,
-                    idx: 0,
-                }
-            }
-        }
-    }
-}
-
-impl<K> NodeBlock<K>
-where
-    K: Clone + Ord,
-{
-    fn number_of_keys(&self) -> usize {
-        self.keys.len()
-    }
-
-    fn is_leaf(&self) -> bool {
-        self.child_nodes.is_empty()
-    }
-
-    /// Finds all children and keys that are inside the range
-    fn find_range<R>(self, range: R) -> Vec<StackEntry<K>>
-    where
-        R: RangeBounds<K>,
-    {
-        let mut result = Vec::with_capacity(self.number_of_keys() + self.child_nodes.len());
-        let node = Rc::new(self);
-
-        // Get first matching item for both the key and children list
-        let first = find_first_candidate(node, range.start_bound());
-        let mut candidate = Some(first);
-
-        // Iterate over all remaining children and keys but stop when end range is reached
-        while let Some(item) = &candidate {
-            let included = match &item {
-                // Always search in child nodes as long as it exists
-                StackEntry::Child { parent, idx } => *idx < parent.child_nodes.len(),
-                // Check if the key is still in range
-                StackEntry::Key { node, idx } => match range.end_bound() {
-                    Bound::Included(end) => *idx < node.keys.len() && &node.keys[*idx] <= end,
-                    Bound::Excluded(end) => *idx < node.keys.len() && &node.keys[*idx] < end,
-                    Bound::Unbounded => *idx < node.keys.len(),
-                },
-            };
-            if included {
-                result.push(item.clone());
-
-                // get the next candidate
-                let next_candidate = match item {
-                    StackEntry::Child { parent, idx } => StackEntry::Key {
-                        node: parent.clone(),
-                        idx: *idx,
-                    },
-                    StackEntry::Key { node, idx } => {
-                        if node.is_leaf() {
-                            StackEntry::Key {
-                                node: node.clone(),
-                                idx: *idx + 1,
-                            }
-                        } else {
-                            StackEntry::Child {
-                                parent: node.clone(),
-                                idx: *idx + 1,
-                            }
-                        }
-                    }
-                };
-                candidate = Some(next_candidate);
-            } else {
-                candidate = None;
-            }
-        }
-
-        result
-    }
-}
 
 /// B-tree index backed by temporary memory mapped files.
 ///
@@ -179,10 +28,9 @@ where
     V: Serialize + DeserializeOwned + Clone,
 {
     nodes: node::NodeFile<K>,
-    node_key_blocks: TemporaryBlockFile<NodeBlock<K>>,
     values: TemporaryBlockFile<V>,
-    root_id: usize,
-    last_inserted_node_id: usize,
+    root_id: u64,
+    last_inserted_node_id: u64,
     order: usize,
     nr_elements: usize,
 }
@@ -249,20 +97,9 @@ where
         if config.order < 2 {
             return Err(Error::OrderTooSmall(config.order));
         }
-
-        // Estimate the needed block size for the root node
-        let empty_struct_size = std::mem::size_of::<NodeBlock<K>>();
-        let keys_vec_size = config.order * config.est_max_key_size;
-        let child_nodes_size = (config.order + 1) * std::mem::size_of::<usize>();
-        let block_size = empty_struct_size + keys_vec_size + child_nodes_size;
         let capacity_in_blocks = capacity / config.order;
 
-        let nodes = NodeFile::with_capacity(capacity / config.order, &config)?;
-
-        let mut node_key_blocks = TemporaryBlockFile::with_capacity(
-            capacity_in_blocks * (block_size + BlockHeader::size()),
-            config.block_cache_size,
-        )?;
+        let mut nodes = NodeFile::with_capacity(capacity / config.order, &config)?;
 
         let values = TemporaryBlockFile::with_capacity(
             (capacity_in_blocks * config.est_max_value_size) + BlockHeader::size(),
@@ -270,19 +107,11 @@ where
         )?;
 
         // Always add an empty root node
-        let root_id = node_key_blocks.allocate_block(page_aligned_capacity(block_size))?;
-        let root_node = NodeBlock {
-            child_nodes: Vec::default(),
-            keys: Vec::default(),
-            payload: Vec::default(),
-            id: root_id,
-        };
-        node_key_blocks.put(root_id, &root_node)?;
+        let root_id = nodes.allocate_new_node()?;
 
         Ok(BtreeIndex {
             root_id,
             nodes,
-            node_key_blocks,
             values,
             order: config.order,
             nr_elements: 0,
@@ -292,9 +121,9 @@ where
 
     /// Searches for a key in the index and returns the value if found.
     pub fn get(&self, key: &K) -> Result<Option<V>> {
-        let root_node = self.node_key_blocks.get(self.root_id)?;
-        if let Some((node, i)) = self.search(root_node, key)? {
-            let v = self.values.get_owned(node.payload[i])?;
+        if let Some((node, i)) = self.search(self.root_id, key)? {
+            let payload_id = self.nodes.get_payload(node, i)?;
+            let v = self.values.get_owned(payload_id.try_into()?)?;
             Ok(Some(v))
         } else {
             Ok(None)
@@ -303,8 +132,7 @@ where
 
     /// Returns whether the index contains the given key.
     pub fn contains_key(&self, key: &K) -> Result<bool> {
-        let root_node = self.node_key_blocks.get(self.root_id)?;
-        Ok(self.search(root_node, key)?.is_some())
+        Ok(self.search(self.root_id, key)?.is_some())
     }
 
     /// Insert a new element into the index.
@@ -313,41 +141,37 @@ where
     /// If the operation fails, you should assume that the whole index is corrupted.
     pub fn insert(&mut self, key: K, value: V) -> Result<Option<V>> {
         // On sorted insert, the last inserted block might the one we need to insert the key into
-        let last_inserted_node = self.node_key_blocks.get(self.last_inserted_node_id)?;
-        if let (Some(start), Some(end)) = (
-            last_inserted_node.keys.first(),
-            last_inserted_node.keys.last(),
-        ) {
-            if &key >= start
-                && &key <= end
-                && last_inserted_node.number_of_keys() < (2 * self.order) - 1
+        let last_inserted_number_keys = self
+            .nodes
+            .number_of_keys(self.last_inserted_node_id)
+            .unwrap_or(0);
+        if last_inserted_number_keys > 0 {
+            let start = self.nodes.get_key(self.last_inserted_node_id, 0)?;
+            let end = self
+                .nodes
+                .get_key(self.last_inserted_node_id, last_inserted_number_keys - 1)?;
+
+            if &key >= start.as_ref()
+                && &key <= end.as_ref()
+                && last_inserted_number_keys < (2 * self.order) - 1
             {
-                let mut copied_node = last_inserted_node.as_ref().clone();
-                let expected = self.insert_nonfull(&mut copied_node, &key, value)?;
+                let expected = self.insert_nonfull(self.last_inserted_node_id, &key, value)?;
                 return Ok(expected);
             }
-        };
+        }
 
-        let mut root_node = self.node_key_blocks.get_owned(self.root_id)?;
-        if root_node.number_of_keys() == (2 * self.order) - 1 {
+        if self.nodes.number_of_keys(self.root_id).unwrap_or(0) == (2 * self.order) - 1 {
             // Create a new root node, because the current will become full
-            let current_root_size = self.node_key_blocks.serialized_size(&root_node)?;
-            let new_root_id = self
-                .node_key_blocks
-                .allocate_block(page_aligned_capacity(current_root_size.try_into()?))?;
+            let new_root_id = self.nodes.allocate_new_node()?;
 
-            let mut new_root: NodeBlock<K> = NodeBlock {
-                id: new_root_id,
-                keys: vec![],
-                payload: vec![],
-                child_nodes: vec![root_node.id],
-            };
-            self.split_child(&mut new_root, 0)?;
-            let existing = self.insert_nonfull(&mut new_root, &key, value)?;
+            self.nodes.set_child_node(new_root_id, 0, self.root_id)?;
+
+            self.split_child(new_root_id, 0)?;
+            let existing = self.insert_nonfull(new_root_id, &key, value)?;
             self.root_id = new_root_id;
             Ok(existing)
         } else {
-            let existing = self.insert_nonfull(&mut root_node, &key, value)?;
+            let existing = self.insert_nonfull(self.root_id, &key, value)?;
             Ok(existing)
         }
     }
@@ -389,10 +213,9 @@ where
         R: RangeBounds<K>,
     {
         // Start to search at the root node
-        let root = self.node_key_blocks.get_owned(self.root_id)?;
         let start = range.start_bound().cloned();
         let end = range.end_bound().cloned();
-        let mut stack = root.find_range(range);
+        let mut stack = self.nodes.find_range(self.root_id, range);
         // The range is sorted by smallest first, but poping values from the end of the
         // stack is more effective
         stack.reverse();
@@ -401,83 +224,81 @@ where
             stack,
             start,
             end,
-            keys: &self.node_key_blocks,
+            nodes: &self.nodes,
             values: &self.values,
             phantom: PhantomData,
         };
         Ok(result)
     }
 
-    fn search(
-        &self,
-        node: Arc<NodeBlock<K>>,
-        key: &K,
-    ) -> Result<Option<(Arc<NodeBlock<K>>, usize)>> {
+    fn search(&self, node_id: u64, key: &K) -> Result<Option<(u64, usize)>> {
         let mut i = 0;
-        while i < node.number_of_keys() && key > &node.keys[i] {
+        let number_of_keys = self.nodes.number_of_keys(node_id)?;
+        let node_key = self.nodes.get_key(node_id, i)?;
+        while i < number_of_keys && key > node_key.as_ref() {
             i += 1;
         }
-        if i < node.number_of_keys() && key == &node.keys[i] {
-            Ok(Some((node, i)))
-        } else if node.is_leaf() {
+        if i < number_of_keys && key == node_key.as_ref() {
+            Ok(Some((node_id, i)))
+        } else if self.nodes.is_leaf(node_id)? {
             Ok(None)
         } else {
             // search in the matching child node
-            let child_block_id = node.child_nodes[i];
-            let child_node = self.node_key_blocks.get(child_block_id)?;
-            self.search(child_node, key)
+            let child_node_id = self.nodes.get_child_node(node_id, i)?;
+            self.search(child_node_id, key)
         }
     }
 
-    fn insert_nonfull(&mut self, node: &mut NodeBlock<K>, key: &K, value: V) -> Result<Option<V>> {
-        match node.keys.binary_search_by(|e| e.cmp(key)) {
-            Ok(i) => {
+    fn insert_nonfull(&mut self, node_id: u64, key: &K, value: V) -> Result<Option<V>> {
+        match self.nodes.binary_search(node_id, key)? {
+            SearchResult::Found(i) => {
                 // Key already exists, replace the payload
-                let payload_id = node.payload[i];
+                let payload_id = self.nodes.get_payload(node_id, i)?.try_into()?;
                 let previous_payload = self.values.get_owned(payload_id)?;
                 self.values.put(payload_id, &value)?;
-                self.last_inserted_node_id = node.id;
+                self.last_inserted_node_id = node_id;
                 Ok(Some(previous_payload))
             }
-            Err(i) => {
-                if node.is_leaf() {
+            SearchResult::NotFound(i) => {
+                if self.nodes.is_leaf(node_id)? {
                     // Insert new key with payload at the given position
                     let value_size: usize = self.values.serialized_size(&value)?.try_into()?;
                     let payload_id = self
                         .values
                         .allocate_block(value_size + BlockHeader::size())?;
                     self.values.put(payload_id, &value)?;
-                    node.keys.insert(i, key.clone());
-                    node.payload.insert(i, payload_id);
-                    self.node_key_blocks.put(node.id, node)?;
+                    self.nodes.set_key(node_id, i, key)?;
+                    self.nodes.set_payload(node_id, i, payload_id.try_into()?)?;
                     self.nr_elements += 1;
-                    self.last_inserted_node_id = node.id;
+                    self.last_inserted_node_id = node_id;
                     Ok(None)
                 } else {
                     // Insert key into correct child
                     // Default to left child
-                    let mut c = self.node_key_blocks.get_owned(node.child_nodes[i])?;
+                    let child_id = self.nodes.get_child_node(node_id, i)?;
                     // If the child is full, we need to split it
-                    if c.number_of_keys() == (2 * self.order) - 1 {
-                        let (mut left, mut right) = self.split_child(node, i)?;
-                        if key == &node.keys[i] {
+                    if self.nodes.number_of_keys(node_id)? == (2 * self.order) - 1 {
+                        let (left, right) = self.split_child(node_id, i)?;
+                        let node_key = self.nodes.get_key(node_id, i)?;
+                        if key == node_key.as_ref() {
                             // Key already exists and was added to the parent node, replace the payload
-                            let payload_id = node.payload[i];
+                            let payload_id: usize =
+                                self.nodes.get_payload(node_id, i)?.try_into()?;
                             let previous_payload = self.values.get_owned(payload_id)?;
                             self.values.put(payload_id, &value)?;
-                            self.last_inserted_node_id = node.id;
+                            self.last_inserted_node_id = node_id;
                             Ok(Some(previous_payload))
-                        } else if key > &node.keys[i] {
+                        } else if key > node_key.as_ref() {
                             // Key is now larger, use the newly created right child
-                            let existing = self.insert_nonfull(&mut right, key, value)?;
+                            let existing = self.insert_nonfull(right, key, value)?;
                             Ok(existing)
                         } else {
                             // Use the updated left child (which has a new key vector)
-                            let existing = self.insert_nonfull(&mut left, key, value)?;
+                            let existing = self.insert_nonfull(left, key, value)?;
                             Ok(existing)
                         }
                     } else {
-                        let existing = self.insert_nonfull(&mut c, key, value)?;
+                        let existing = self.insert_nonfull(child_id, key, value)?;
                         Ok(existing)
                     }
                 }
@@ -485,74 +306,34 @@ where
         }
     }
 
-    fn split_child(
-        &mut self,
-        parent: &mut NodeBlock<K>,
-        i: usize,
-    ) -> Result<(NodeBlock<K>, NodeBlock<K>)> {
-        // Allocate a new block and use the original child block capacity as hint for the needed capacity
-        let mut existing_node = self.node_key_blocks.get_owned(parent.child_nodes[i])?;
-        let existing_node_size = self.node_key_blocks.serialized_size(&existing_node)?;
-        let new_node_id = self
-            .node_key_blocks
-            .allocate_block(page_aligned_capacity(existing_node_size.try_into()?))?;
-
-        let new_node_keys = existing_node.keys.split_off(self.order);
-        let new_payload = existing_node.payload.split_off(self.order);
-        let new_node_children = if existing_node.is_leaf() {
-            vec![]
-        } else {
-            existing_node.child_nodes.split_off(self.order)
-        };
-
-        let new_node = NodeBlock {
-            child_nodes: new_node_children,
-            keys: new_node_keys,
-            payload: new_payload,
-            id: new_node_id,
-        };
-
-        // Insert the new child entry and the key
-        let split_key = existing_node
-            .keys
-            .pop()
-            .ok_or(Error::EmptyChildNodeInSplit)?;
-        let split_payload = existing_node
-            .payload
-            .pop()
-            .ok_or(Error::EmptyChildNodeInSplit)?;
-        parent.keys.insert(i, split_key);
-        parent.payload.insert(i, split_payload);
-        parent.child_nodes.insert(i + 1, new_node_id);
-
-        // Save all changed files
-        self.node_key_blocks.put(new_node.id, &new_node)?;
-        self.node_key_blocks.put(parent.id, parent)?;
-        self.node_key_blocks.put(existing_node.id, &existing_node)?;
-
-        Ok((existing_node, new_node))
+    fn split_child(&mut self, parent_node_id: u64, child_idx: usize) -> Result<(u64, u64)> {
+        let (existing_node, new_node_id) =
+            self.nodes
+                .split_child(parent_node_id, child_idx, self.order)?;
+        Ok((existing_node, new_node_id))
     }
-}
-
-#[derive(Clone)]
-enum StackEntry<K> {
-    Child {
-        parent: Rc<NodeBlock<K>>,
-        idx: usize,
-    },
-    Key {
-        node: Rc<NodeBlock<K>>,
-        idx: usize,
-    },
 }
 
 pub struct Range<'a, K, V> {
     start: Bound<K>,
     end: Bound<K>,
-    keys: &'a TemporaryBlockFile<NodeBlock<K>>,
+    nodes: &'a NodeFile<K>,
     values: &'a TemporaryBlockFile<V>,
-    stack: Vec<StackEntry<K>>,
+    stack: Vec<node::StackEntry>,
     phantom: PhantomData<V>,
+}
+
+impl<'a, K, V> Range<'a, K, V>
+where
+    K: Clone + Serialize + DeserializeOwned + Ord,
+    V: Clone + Serialize + DeserializeOwned,
+{
+    fn get_key_value_tuple(&self, node: u64, idx: usize) -> Result<(K, V)> {
+        let payload_id = self.nodes.get_payload(node, idx)?;
+        let value = self.values.get_owned(payload_id.try_into()?)?;
+        let key = self.nodes.get_key_owned(node, idx)?;
+        Ok((key, value))
+    }
 }
 
 impl<'a, K, V> Iterator for Range<'a, K, V>
@@ -566,28 +347,26 @@ where
         while let Some(e) = self.stack.pop() {
             match e {
                 StackEntry::Child { parent, idx } => {
-                    match self.keys.get_owned(parent.child_nodes[idx]) {
+                    match self.nodes.get_child_node(parent, idx) {
                         Ok(c) => {
                             // Add all entries for this child node on the stack
-                            let mut new_elements =
-                                c.find_range((self.start.clone(), self.end.clone()));
+                            let mut new_elements = self
+                                .nodes
+                                .find_range(c, (self.start.clone(), self.end.clone()));
                             new_elements.reverse();
                             self.stack.extend(new_elements.into_iter());
                         }
                         Err(e) => return Some(Err(e)),
                     }
                 }
-                StackEntry::Key { node, idx } => {
-                    let payload_id = node.payload[idx];
-                    match self.values.get_owned(payload_id) {
-                        Ok(v) => {
-                            return Some(Ok((node.keys[idx].clone(), v)));
-                        }
-                        Err(e) => {
-                            return Some(Err(e));
-                        }
+                StackEntry::Key { node, idx } => match self.get_key_value_tuple(node, idx) {
+                    Ok(result) => {
+                        return Some(Ok(result));
                     }
-                }
+                    Err(e) => {
+                        return Some(Err(e));
+                    }
+                },
             }
         }
 

--- a/src/btree.rs
+++ b/src/btree.rs
@@ -166,7 +166,7 @@ where
         if root_number_of_keys == (2 * self.order) - 1 {
             // Create a new root node, because the current will become full
             let new_root_id = self.nodes.split_root_node(self.root_id, self.order)?;
-         
+
             let existing = self.insert_nonfull(new_root_id, &key, value)?;
             self.root_id = new_root_id;
             Ok(existing)

--- a/src/btree.rs
+++ b/src/btree.rs
@@ -277,7 +277,7 @@ where
                     // Default to left child
                     let child_id = self.nodes.get_child_node(node_id, i)?;
                     // If the child is full, we need to split it
-                    if self.nodes.number_of_keys(node_id)? == (2 * self.order) - 1 {
+                    if self.nodes.number_of_keys(child_id)? == (2 * self.order) - 1 {
                         let (left, right) = self.nodes.split_child(node_id, i, self.order)?;
                         let node_key = self.nodes.get_key(node_id, i)?;
                         if key == node_key.as_ref() {

--- a/src/btree.rs
+++ b/src/btree.rs
@@ -57,7 +57,7 @@ impl Default for BtreeConfig {
 impl BtreeConfig {
     /// Set the estimated maximum size in bytes for each key.
     ///
-    /// Keys can be larger than this, but if this happens too often the block for the key 
+    /// Keys can be larger than this, but if this happens too often the block for the key
     /// might need to be re-allocated, which causes memory fragmentation on the disk
     /// and some main memory overhead for remembering the re-allocated block IDs.
     pub fn max_key_size(mut self, est_max_key_size: usize) -> Self {
@@ -66,8 +66,8 @@ impl BtreeConfig {
     }
 
     /// Set the estimated maximum size in bytes for each values.
-    /// 
-    /// Values can be larger than this, but if this happens too often the block for the value 
+    ///
+    /// Values can be larger than this, but if this happens too often the block for the value
     /// might need to be re-allocated, which causes memory fragmentation on the disk
     /// and some main memory overhead for remembering the re-allocated block IDs.
     pub fn max_value_size(mut self, est_max_value_size: usize) -> Self {
@@ -77,9 +77,9 @@ impl BtreeConfig {
 
     /// Sets the order of the tree, which determines how many elements a single node can store.
     ///
-    /// A B-tree is balanced, so the number of keys of a node is between the order and the order times two. 
-    /// The order must be at least 2 and at most 84 for this implementation, and 
-    /// it is guaranteed that the internal structure for a node always fits inside a memory page. 
+    /// A B-tree is balanced, so the number of keys of a node is between the order and the order times two.
+    /// The order must be at least 2 and at most 84 for this implementation, and
+    /// it is guaranteed that the internal structure for a node always fits inside a memory page.
     /// The default is to use the maximum number of keys, so the memory page is utilized as much as possible.
     pub fn order(mut self, order: u8) -> Self {
         self.order = order as usize;

--- a/src/btree/node.rs
+++ b/src/btree/node.rs
@@ -151,19 +151,13 @@ where
 
                 // get the next candidate
                 let next_candidate = match item {
-                    StackEntry::Child { parent, idx } => StackEntry::Key {
-                        node: parent.clone(),
-                        idx: idx,
-                    },
+                    StackEntry::Child { parent, idx } => StackEntry::Key { node: parent, idx },
                     StackEntry::Key { node, idx } => {
                         if self.is_leaf(node).unwrap_or(false) {
-                            StackEntry::Key {
-                                node: node.clone(),
-                                idx: idx + 1,
-                            }
+                            StackEntry::Key { node, idx: idx + 1 }
                         } else {
                             StackEntry::Child {
-                                parent: node.clone(),
+                                parent: node,
                                 idx: idx + 1,
                             }
                         }
@@ -298,7 +292,7 @@ where
             let offset = i * 8;
             let key_size: usize = self.keys.serialized_size(key)?.try_into()?;
             let key_id = self.keys.allocate_block(key_size + BlockHeader::size())?;
-            self.keys.put(key_id, &key)?;
+            self.keys.put(key_id, key)?;
 
             let key_id: u64 = key_id.try_into()?;
             let key_id = key_id.to_le_bytes();
@@ -509,14 +503,14 @@ where
         }
     }
 
-    fn get<'a>(&'a self, node_id: u64) -> Result<node::View<&[u8]>> {
+    fn get(&self, node_id: u64) -> Result<node::View<&[u8]>> {
         let node_id: usize = node_id.try_into()?;
         let offset: usize = NODE_BLOCK_ALIGNED_SIZE * node_id;
         let view = node::View::new(&self.mmap[offset..(offset + NODE_BLOCK_SIZE)]);
         Ok(view)
     }
 
-    fn get_mut<'a>(&'a mut self, node_id: u64) -> Result<node::View<&mut [u8]>> {
+    fn get_mut(&mut self, node_id: u64) -> Result<node::View<&mut [u8]>> {
         let node_id: usize = node_id.try_into()?;
         let offset: usize = NODE_BLOCK_ALIGNED_SIZE * node_id;
         let view = node::View::new(&mut self.mmap[offset..(offset + NODE_BLOCK_SIZE)]);

--- a/src/btree/node.rs
+++ b/src/btree/node.rs
@@ -365,6 +365,7 @@ where
             let offset = i * 8;
             let value = value.to_le_bytes();
             view.child_nodes_mut().data_mut()[offset..(offset + 8)].copy_from_slice(&value);
+            view.is_leaf_mut().write(0);
             Ok(())
         } else {
             Err(Error::KeyIndexOutOfBounds { idx: i, len: n })
@@ -422,8 +423,8 @@ where
         }
         // The last element of the existing node is dangling without a child node,
         // use it as the key for the parent node
-        let split_key = self.get_key(existing_node, split_at)?;
-        let split_payload = self.get_payload(existing_node, split_at)?;
+        let split_key = self.get_key(existing_node, split_at-1)?;
+        let split_payload = self.get_payload(existing_node, split_at-1)?;
         let mut existing_node_view = self.get_mut(existing_node)?;
         existing_node_view
             .num_keys_mut()
@@ -465,8 +466,8 @@ where
 
         // The last element of the previous root node is dangling without a child node,
         // use it as the key for the parent node
-        let split_key = self.get_key(old_root_id, split_at)?;
-        let split_payload = self.get_payload(old_root_id, split_at)?;
+        let split_key = self.get_key(old_root_id, split_at-1)?;
+        let split_payload = self.get_payload(old_root_id, split_at-1)?;
         let mut existing_node_view = self.get_mut(old_root_id)?;
         existing_node_view
             .num_keys_mut()

--- a/src/btree/node.rs
+++ b/src/btree/node.rs
@@ -97,7 +97,7 @@ where
     }
 
     pub fn number_of_children(&self, node_id: u64) -> Result<usize> {
-        if self.is_leaf(node_id)? {
+        if !self.is_leaf(node_id)? {
             Ok(self.number_of_keys(node_id)? + 1)
         } else {
             Ok(0)

--- a/src/btree/node.rs
+++ b/src/btree/node.rs
@@ -1,0 +1,160 @@
+use std::marker::PhantomData;
+
+use crate::BtreeConfig;
+use crate::error::Result;
+use crate::file::{TemporaryBlockFile, BlockHeader};
+use binary_layout::{prelude::*, FieldView};
+use memmap2::{MmapMut, MmapOptions};
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+
+// Defines a single BTree node with references to the actual values in a tuple file
+// This node can up to 1361 keys and 1362 child node references.
+define_layout!(node, LittleEndian, {
+    id: u64,
+    num_keys: u16,
+    is_leaf: u8,
+    keys: [u8; 10888],
+    payloads: [u8; 10888],
+    child_nodes: [u8; 10896],
+});
+
+const NODE_BLOCK_SIZE: usize = 4095;
+const NODE_BLOCK_ALIGNED_SIZE: usize = 4096;
+
+pub fn get_key(field: &FieldView<&[u8], node::keys>, i: usize) -> Result<u64> {
+    let offset = i * 8;
+    let result: u64 = u64::from_le_bytes(field.data()[offset..(offset + 8)].try_into()?);
+    Ok(result)
+}
+
+pub fn set_key(field: &mut FieldView<&mut [u8], node::keys>, i: usize, value: usize) {
+    let offset = i * 8;
+    let value = value.to_le_bytes();
+    field.data_mut()[offset..].copy_from_slice(&value);
+}
+
+pub fn get_payload(field: &FieldView<&[u8], node::payloads>, i: usize) -> Result<u64> {
+    let offset = i * 8;
+    let result: u64 = u64::from_le_bytes(field.data()[offset..(offset + 8)].try_into()?);
+    Ok(result)
+}
+
+pub fn set_payload(field: &mut FieldView<&mut [u8], node::payloads>, i: usize, value: usize) {
+    let offset = i * 8;
+    let value = value.to_le_bytes();
+    field.data_mut()[offset..].copy_from_slice(&value);
+}
+
+pub fn get_child_node(field: &FieldView<&[u8], node::child_nodes>, i: usize) -> Result<u64> {
+    let offset = i * 8;
+    let result: u64 = u64::from_le_bytes(field.data()[offset..(offset + 8)].try_into()?);
+    Ok(result)
+}
+
+pub fn set_child_node(field: &mut FieldView<&mut [u8], node::child_nodes>, i: usize, value: usize) {
+    let offset = i * 8;
+    let value = value.to_le_bytes();
+    field.data_mut()[offset..].copy_from_slice(&value);
+}
+
+
+pub struct NodeFile<K> {
+    free_space_offset: usize,
+    mmap: MmapMut,
+    keys: TemporaryBlockFile<K>,
+}
+
+impl<K> NodeFile<K>
+where K: Serialize + DeserializeOwned + Clone {
+    pub fn with_capacity(capacity: usize, config : &BtreeConfig) -> Result<NodeFile<K>> {
+        // Create an anonymous memory mapped file with the capacity as size
+        let capacity = capacity.max(1);
+        let mmap = MmapOptions::new()
+            .stack()
+            .len(capacity * NODE_BLOCK_ALIGNED_SIZE)
+            .map_anon()?;
+
+        // Each node can hold 1361 keys, so we need the space for them as well
+        let number_of_keys = capacity * 1361;
+        let keys = TemporaryBlockFile::with_capacity((number_of_keys * config.est_max_value_size) + BlockHeader::size(),
+            config.block_cache_size,
+        )?;
+
+        Ok(NodeFile {
+            mmap,
+            keys,
+            free_space_offset: 0,
+        })
+    }
+    fn number_of_keys(&self, node_id : u64) -> Result<usize> {
+        let view = self.get(node_id)?;
+        Ok(view.num_keys().read() as usize)
+    }
+
+    fn is_leaf(&self, node_id : u64) -> Result<bool> {
+        let view = self.get(node_id)?;
+        Ok(view.is_leaf().read() != 0)
+    }
+
+    fn get<'a>(&'a self, node_id: u64) -> Result<node::View<&[u8]>> {
+        let node_id: usize = node_id.try_into()?;
+        let offset: usize = NODE_BLOCK_ALIGNED_SIZE * node_id;
+        let view = node::View::new(&self.mmap[offset..(offset + NODE_BLOCK_SIZE)]);
+        Ok(view)
+    }
+
+    fn get_mut<'a>(&'a mut self, node_id: u64) -> Result<node::View<&mut [u8]>> {
+        let node_id: usize = node_id.try_into()?;
+        let offset: usize = NODE_BLOCK_ALIGNED_SIZE * node_id;
+        let view = node::View::new(&mut self.mmap[offset..(offset + NODE_BLOCK_SIZE)]);
+        Ok(view)
+    }
+
+    
+
+
+    /// Allocate a new node.
+    ///
+    /// Returns the ID of the new node.
+    pub fn allocate_block(&mut self) -> Result<u64> {
+        // Make sure we still have enough space left
+        let new_offset = self.free_space_offset + NODE_BLOCK_ALIGNED_SIZE;
+        self.grow(new_offset)?;
+
+        // Return the old start of free space as block index
+        let result: u64 = (self.free_space_offset / NODE_BLOCK_ALIGNED_SIZE).try_into()?;
+
+        // Initialize some of the values
+        self.get_mut(result)?.num_keys_mut().write(0);
+        self.get_mut(result)?.is_leaf_mut().write(1);
+
+        // The next free block can be added after this block
+        self.free_space_offset = new_offset;
+        Ok(result)
+    }
+
+    /// Grows the file to contain at least the requested number of bytes.
+    /// This needs to copy all content into a new temporary file.
+    /// To avoid this costly operation, the file size is at least doubled.
+    fn grow(&mut self, requested_size: usize) -> Result<()> {
+        if requested_size <= self.mmap.len() {
+            // Still enough space, no action required
+            return Ok(());
+        }
+
+        // Create a new anonymous memory mapped the content is copied to.
+        // Allocate at least twice the old file size so we don't need to grow too often
+        let new_size = requested_size.max(self.mmap.len() * 2);
+        let mut new_mmap = MmapOptions::new().stack().len(new_size).map_anon()?;
+
+        // Copy all content from the old file into the new file
+        new_mmap[0..self.mmap.len()].copy_from_slice(&self.mmap);
+
+        self.mmap = new_mmap;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/btree/node.rs
+++ b/src/btree/node.rs
@@ -411,22 +411,6 @@ where
         // Allocate a new block for the new child node
         let new_node_id = self.split_off(existing_node, split_at)?;
 
-        // Make space for the new key by moving all other entries to the right
-        for i in self.number_of_keys(parent_node_id)?..=child_idx {
-            self.set_key(
-                parent_node_id,
-                i,
-                self.get_key(parent_node_id, i - 1)?.as_ref(),
-            )?;
-            self.set_payload(parent_node_id, i, self.get_payload(parent_node_id, i - 1)?)?;
-        }
-        for i in self.number_of_children(parent_node_id)?..child_idx {
-            self.set_child_node(
-                parent_node_id,
-                i,
-                self.get_child_node(parent_node_id, i - 1)?,
-            )?;
-        }
         // The last element of the existing node is dangling without a child node,
         // use it as the key for the parent node
         let split_key = self.get_key(existing_node, split_at - 1)?;
@@ -437,7 +421,7 @@ where
             .write((split_at - 1).try_into()?);
 
         // Make space for the new entry in the parent node
-        for i in self.number_of_keys(parent_node_id)?..child_idx {
+        for i in ((child_idx + 1)..=self.number_of_keys(parent_node_id)?).rev() {
             self.set_key(
                 parent_node_id,
                 i,
@@ -445,7 +429,7 @@ where
             )?;
             self.set_payload(parent_node_id, i, self.get_payload(parent_node_id, i - 1)?)?;
         }
-        for i in self.number_of_children(parent_node_id)?..(child_idx + 1) {
+        for i in ((child_idx + 1)..=self.number_of_children(parent_node_id)?).rev() {
             self.set_child_node(
                 parent_node_id,
                 i,

--- a/src/btree/node.rs
+++ b/src/btree/node.rs
@@ -1,12 +1,20 @@
-use std::marker::PhantomData;
+use std::cmp::Ordering;
+use std::ops::{Bound, RangeBounds};
+use std::sync::Arc;
 
-use crate::BtreeConfig;
 use crate::error::Result;
-use crate::file::{TemporaryBlockFile, BlockHeader};
-use binary_layout::{prelude::*, FieldView};
+use crate::file::{BlockHeader, TemporaryBlockFile};
+use crate::{BtreeConfig, Error};
+use binary_layout::prelude::*;
 use memmap2::{MmapMut, MmapOptions};
 use serde::de::DeserializeOwned;
 use serde::Serialize;
+
+const NODE_BLOCK_SIZE: usize = 4095;
+const NODE_BLOCK_ALIGNED_SIZE: usize = 4096;
+
+const MAX_NUMBER_KEYS: usize = 10888;
+const MAX_NUMBER_CHILD_NODES: usize = MAX_NUMBER_KEYS + 1;
 
 // Defines a single BTree node with references to the actual values in a tuple file
 // This node can up to 1361 keys and 1362 child node references.
@@ -14,50 +22,10 @@ define_layout!(node, LittleEndian, {
     id: u64,
     num_keys: u16,
     is_leaf: u8,
-    keys: [u8; 10888],
-    payloads: [u8; 10888],
-    child_nodes: [u8; 10896],
+    keys: [u8; MAX_NUMBER_KEYS],
+    payloads: [u8; MAX_NUMBER_KEYS],
+    child_nodes: [u8; MAX_NUMBER_CHILD_NODES],
 });
-
-const NODE_BLOCK_SIZE: usize = 4095;
-const NODE_BLOCK_ALIGNED_SIZE: usize = 4096;
-
-pub fn get_key(field: &FieldView<&[u8], node::keys>, i: usize) -> Result<u64> {
-    let offset = i * 8;
-    let result: u64 = u64::from_le_bytes(field.data()[offset..(offset + 8)].try_into()?);
-    Ok(result)
-}
-
-pub fn set_key(field: &mut FieldView<&mut [u8], node::keys>, i: usize, value: usize) {
-    let offset = i * 8;
-    let value = value.to_le_bytes();
-    field.data_mut()[offset..].copy_from_slice(&value);
-}
-
-pub fn get_payload(field: &FieldView<&[u8], node::payloads>, i: usize) -> Result<u64> {
-    let offset = i * 8;
-    let result: u64 = u64::from_le_bytes(field.data()[offset..(offset + 8)].try_into()?);
-    Ok(result)
-}
-
-pub fn set_payload(field: &mut FieldView<&mut [u8], node::payloads>, i: usize, value: usize) {
-    let offset = i * 8;
-    let value = value.to_le_bytes();
-    field.data_mut()[offset..].copy_from_slice(&value);
-}
-
-pub fn get_child_node(field: &FieldView<&[u8], node::child_nodes>, i: usize) -> Result<u64> {
-    let offset = i * 8;
-    let result: u64 = u64::from_le_bytes(field.data()[offset..(offset + 8)].try_into()?);
-    Ok(result)
-}
-
-pub fn set_child_node(field: &mut FieldView<&mut [u8], node::child_nodes>, i: usize, value: usize) {
-    let offset = i * 8;
-    let value = value.to_le_bytes();
-    field.data_mut()[offset..].copy_from_slice(&value);
-}
-
 
 pub struct NodeFile<K> {
     free_space_offset: usize,
@@ -65,9 +33,22 @@ pub struct NodeFile<K> {
     keys: TemporaryBlockFile<K>,
 }
 
+pub enum SearchResult {
+    Found(usize),
+    NotFound(usize),
+}
+
+#[derive(Clone)]
+pub enum StackEntry {
+    Child { parent: u64, idx: usize },
+    Key { node: u64, idx: usize },
+}
+
 impl<K> NodeFile<K>
-where K: Serialize + DeserializeOwned + Clone {
-    pub fn with_capacity(capacity: usize, config : &BtreeConfig) -> Result<NodeFile<K>> {
+where
+    K: Serialize + DeserializeOwned + Clone + Ord,
+{
+    pub fn with_capacity(capacity: usize, config: &BtreeConfig) -> Result<NodeFile<K>> {
         // Create an anonymous memory mapped file with the capacity as size
         let capacity = capacity.max(1);
         let mmap = MmapOptions::new()
@@ -77,7 +58,8 @@ where K: Serialize + DeserializeOwned + Clone {
 
         // Each node can hold 1361 keys, so we need the space for them as well
         let number_of_keys = capacity * 1361;
-        let keys = TemporaryBlockFile::with_capacity((number_of_keys * config.est_max_value_size) + BlockHeader::size(),
+        let keys = TemporaryBlockFile::with_capacity(
+            (number_of_keys * config.est_max_value_size) + BlockHeader::size(),
             config.block_cache_size,
         )?;
 
@@ -87,14 +69,430 @@ where K: Serialize + DeserializeOwned + Clone {
             free_space_offset: 0,
         })
     }
-    fn number_of_keys(&self, node_id : u64) -> Result<usize> {
+
+    /// Allocate a new node.
+    ///
+    /// Returns the ID of the new node.
+    pub fn allocate_new_node(&mut self) -> Result<u64> {
+        // Make sure we still have enough space left
+        let new_offset = self.free_space_offset + NODE_BLOCK_ALIGNED_SIZE;
+        self.grow(new_offset)?;
+
+        // Return the old start of free space as block index
+        let result: u64 = (self.free_space_offset / NODE_BLOCK_ALIGNED_SIZE).try_into()?;
+
+        // Initialize some of the values
+        self.get_mut(result)?.id_mut().write(result);
+        self.get_mut(result)?.num_keys_mut().write(0);
+        self.get_mut(result)?.is_leaf_mut().write(1);
+
+        // The next free block can be added after this block
+        self.free_space_offset = new_offset;
+        Ok(result)
+    }
+
+    pub fn number_of_keys(&self, node_id: u64) -> Result<usize> {
         let view = self.get(node_id)?;
         Ok(view.num_keys().read() as usize)
     }
 
-    fn is_leaf(&self, node_id : u64) -> Result<bool> {
+    pub fn number_of_children(&self, node_id: u64) -> Result<usize> {
+        if self.is_leaf(node_id)? {
+            Ok(self.number_of_keys(node_id)? + 1)
+        } else {
+            Ok(0)
+        }
+    }
+
+    pub fn is_leaf(&self, node_id: u64) -> Result<bool> {
         let view = self.get(node_id)?;
         Ok(view.is_leaf().read() != 0)
+    }
+
+    /// Finds all children and keys that are inside the range
+    pub fn find_range<R>(&self, node_id: u64, range: R) -> Vec<StackEntry>
+    where
+        R: RangeBounds<K>,
+    {
+        let mut result: Vec<StackEntry> =
+            Vec::with_capacity(2 * (self.number_of_keys(node_id).unwrap_or(1024) + 1));
+
+        // Get first matching item for both the key and children list
+        let mut candidate = self.find_first_candidate(node_id, range.start_bound()).ok();
+
+        // Iterate over all remaining children and keys but stop when end range is reached
+        while let Some(item) = candidate {
+            let included = match &item {
+                // Always search in child nodes as long as it exists
+                StackEntry::Child { parent, idx } => {
+                    *idx < self.number_of_children(*parent).unwrap_or(0)
+                }
+                // Check if the key is still in range
+                StackEntry::Key { node, idx } => match range.end_bound() {
+                    Bound::Included(end) => {
+                        if let Ok(key) = self.get_key(*node, *idx) {
+                            key.as_ref() <= end
+                        } else {
+                            false
+                        }
+                    }
+                    Bound::Excluded(end) => {
+                        if let Ok(key) = self.get_key(*node, *idx) {
+                            key.as_ref() < end
+                        } else {
+                            false
+                        }
+                    }
+                    Bound::Unbounded => *idx < self.number_of_keys(*node).unwrap_or(0),
+                },
+            };
+            if included {
+                result.push(item.clone());
+
+                // get the next candidate
+                let next_candidate = match item {
+                    StackEntry::Child { parent, idx } => StackEntry::Key {
+                        node: parent.clone(),
+                        idx: idx,
+                    },
+                    StackEntry::Key { node, idx } => {
+                        if self.is_leaf(node).unwrap_or(false) {
+                            StackEntry::Key {
+                                node: node.clone(),
+                                idx: idx + 1,
+                            }
+                        } else {
+                            StackEntry::Child {
+                                parent: node.clone(),
+                                idx: idx + 1,
+                            }
+                        }
+                    }
+                };
+                candidate = Some(next_candidate);
+            } else {
+                candidate = None;
+            }
+        }
+
+        result
+    }
+
+    fn find_first_candidate(&self, node_id: u64, start_bound: Bound<&K>) -> Result<StackEntry> {
+        let result = match start_bound {
+            Bound::Included(key) => {
+                let key_pos = self.binary_search(node_id, key)?;
+                match &key_pos {
+                    // Key was found, start at this position
+                    SearchResult::Found(i) => StackEntry::Key {
+                        node: node_id,
+                        idx: *i,
+                    },
+                    // Key not found, but key would be inserted at i, so the next child or key could contain the key
+                    SearchResult::NotFound(i) => {
+                        if self.is_leaf(node_id)? {
+                            // When searching for for example for 5 in a leaf [2,4,8], i would be 3 and we need to
+                            // start our search at the third key.
+                            // If the search range is after the largest key (e.g. 10 for the previous example),
+                            // the binary search will return the length of the vector as insertion position,
+                            // effectivly generating an invalid candidate which needs to be filterred later
+                            StackEntry::Key {
+                                node: node_id,
+                                idx: *i,
+                            }
+                        } else {
+                            StackEntry::Child {
+                                parent: node_id,
+                                idx: *i,
+                            }
+                        }
+                    }
+                }
+            }
+            Bound::Excluded(key) => {
+                let key_pos = self.binary_search(node_id, key)?;
+                match &key_pos {
+                    // Key was found, start at child or key after the key
+                    SearchResult::Found(i) => {
+                        if self.is_leaf(node_id)? {
+                            StackEntry::Key {
+                                node: node_id,
+                                idx: *i + 1,
+                            }
+                        } else {
+                            StackEntry::Child {
+                                parent: node_id,
+                                idx: *i + 1,
+                            }
+                        }
+                    }
+                    // Key not found, but key would be inserted at i, so the previous child could contain the key
+                    // E.g. when searching for 5 in [c0, k0=2, c1, k1=4, c2, k2=8, c3 ], i would be 2 and we need to
+                    // start our search a c2 which is before this key.
+                    SearchResult::NotFound(i) => {
+                        if self.is_leaf(node_id)? {
+                            StackEntry::Key {
+                                node: node_id,
+                                idx: *i,
+                            }
+                        } else {
+                            StackEntry::Child {
+                                parent: node_id,
+                                idx: *i,
+                            }
+                        }
+                    }
+                }
+            }
+            Bound::Unbounded => {
+                if self.is_leaf(node_id)? {
+                    // Return the first key
+                    StackEntry::Key {
+                        node: node_id,
+                        idx: 0,
+                    }
+                } else {
+                    // Return the first child
+                    StackEntry::Child {
+                        parent: node_id,
+                        idx: 0,
+                    }
+                }
+            }
+        };
+        Ok(result)
+    }
+
+    /// Get a block with the given id give ownership of the result to the caller.
+    pub fn get_key_owned(&self, node_id: u64, i: usize) -> Result<K> {
+        let view = self.get(node_id)?;
+        let n: usize = view.num_keys().read() as usize;
+        if i < n {
+            let offset = i * 8;
+            let key_id: u64 =
+                u64::from_le_bytes(view.keys().data()[offset..(offset + 8)].try_into()?);
+            let result = self.keys.get_owned(key_id.try_into()?)?;
+            Ok(result)
+        } else {
+            Err(Error::KeyIndexOutOfBounds { idx: i, len: n })
+        }
+    }
+
+    pub fn get_key(&self, node_id: u64, i: usize) -> Result<Arc<K>> {
+        let view = self.get(node_id)?;
+        let n: usize = view.num_keys().read() as usize;
+        if i < n {
+            let offset = i * 8;
+            let key_id: u64 =
+                u64::from_le_bytes(view.keys().data()[offset..(offset + 8)].try_into()?);
+            let result = self.keys.get(key_id.try_into()?)?;
+            Ok(result)
+        } else {
+            Err(Error::KeyIndexOutOfBounds { idx: i, len: n })
+        }
+    }
+
+    pub fn set_key(&mut self, node_id: u64, i: usize, key: &K) -> Result<()> {
+        let view = self.get(node_id)?;
+        let n: usize = view.num_keys().read() as usize;
+        if i <= n && i < MAX_NUMBER_KEYS {
+            let offset = i * 8;
+            let key_id: u64 =
+                u64::from_le_bytes(view.keys().data()[offset..(offset + 8)].try_into()?);
+            self.keys.put(key_id.try_into()?, &key)?;
+            if i == n {
+                // The key was inserted at the end of the list
+                let mut view = self.get_mut(node_id)?;
+                let n: u16 = (n + 1).try_into()?;
+                view.num_keys_mut().write(n);
+            }
+            Ok(())
+        } else {
+            Err(Error::KeyIndexOutOfBounds { idx: i, len: n })
+        }
+    }
+
+    pub fn get_payload(&self, node_id: u64, i: usize) -> Result<u64> {
+        let view = self.get(node_id)?;
+        let n: usize = view.num_keys().read() as usize;
+        if i < n {
+            let offset = i * 8;
+            let result: u64 =
+                u64::from_le_bytes(view.payloads().data()[offset..(offset + 8)].try_into()?);
+            Ok(result)
+        } else {
+            Err(Error::KeyIndexOutOfBounds { idx: i, len: n })
+        }
+    }
+
+    pub fn set_payload(&mut self, node_id: u64, i: usize, value: u64) -> Result<()> {
+        let mut view = self.get_mut(node_id)?;
+        let n: usize = view.num_keys().read() as usize;
+        if i < n {
+            let offset = i * 8;
+            let value = value.to_le_bytes();
+            view.payloads_mut().data_mut()[offset..].copy_from_slice(&value);
+            Ok(())
+        } else {
+            Err(Error::KeyIndexOutOfBounds { idx: i, len: n })
+        }
+    }
+
+    pub fn get_child_node(&self, node_id: u64, i: usize) -> Result<u64> {
+        let view = self.get(node_id)?;
+        let n: usize = view.num_keys().read() as usize;
+        let has_children: bool = view.is_leaf().read() == 0;
+        if has_children && i < (n + 1) {
+            let offset = i * 8;
+            let result: u64 =
+                u64::from_le_bytes(view.child_nodes().data()[offset..(offset + 8)].try_into()?);
+            Ok(result)
+        } else {
+            Err(Error::KeyIndexOutOfBounds { idx: i, len: n })
+        }
+    }
+
+    pub fn set_child_node(&mut self, node_id: u64, i: usize, value: u64) -> Result<()> {
+        let mut view = self.get_mut(node_id)?;
+        let has_children: bool = view.is_leaf().read() == 0;
+        let n: usize = if has_children {
+            (view.num_keys().read() as usize) + 1
+        } else {
+            0
+        };
+
+        if i <= n && i < MAX_NUMBER_CHILD_NODES {
+            let offset = i * 8;
+            let value = value.to_le_bytes();
+            view.child_nodes_mut().data_mut()[offset..].copy_from_slice(&value);
+            Ok(())
+        } else {
+            Err(Error::KeyIndexOutOfBounds { idx: i, len: n })
+        }
+    }
+
+    pub fn binary_search(&self, node_id: u64, key: &K) -> Result<SearchResult> {
+        let mut size = self.number_of_keys(node_id).unwrap_or(0);
+        let mut left = 0;
+        let mut right = size;
+        while left < right {
+            let mid = left + size / 2;
+
+            let mid_key = self.get_key(node_id, mid).unwrap();
+            let cmp = mid_key.as_ref().cmp(key);
+
+            if cmp == Ordering::Less {
+                left = mid + 1;
+            } else if cmp == Ordering::Greater {
+                right = mid;
+            } else {
+                return Ok(SearchResult::Found(mid));
+            }
+
+            size = right - left;
+        }
+        Ok(SearchResult::NotFound(left))
+    }
+
+    pub fn split_child(
+        &mut self,
+        parent_node_id: u64,
+        child_idx: usize,
+        split_at: usize,
+    ) -> Result<(u64, u64)> {
+        // Use the index the get the actual node ID from the parent node
+        let existing_node = self.get_child_node(parent_node_id, child_idx)?;
+        // Allocate a new block for the new child node
+        let new_node_id = self.split_off(existing_node, split_at)?;
+
+        // Make space for the new key by moving all other entries to the right
+        for i in self.number_of_keys(parent_node_id)?..=child_idx {
+            self.set_key(
+                parent_node_id,
+                i,
+                self.get_key(parent_node_id, i - 1)?.as_ref(),
+            )?;
+            self.set_payload(parent_node_id, i, self.get_payload(parent_node_id, i - 1)?)?;
+        }
+        for i in self.number_of_children(parent_node_id)?..child_idx {
+            self.set_child_node(
+                parent_node_id,
+                i,
+                self.get_child_node(parent_node_id, i - 1)?,
+            )?;
+        }
+        // The last element of the existing node is dangling without a child node,
+        // use it as the key for the parent node
+        let split_key = self.get_key(existing_node, split_at)?;
+        let split_payload = self.get_payload(existing_node, split_at)?;
+        let mut existing_node_view = self.get_mut(existing_node)?;
+        existing_node_view
+            .num_keys_mut()
+            .write((split_at - 1).try_into()?);
+
+        // Make space for the new entry in the parent node
+        for i in self.number_of_keys(parent_node_id)?..child_idx {
+            self.set_key(
+                parent_node_id,
+                i,
+                self.get_key(parent_node_id, i - 1)?.as_ref(),
+            )?;
+            self.set_payload(parent_node_id, i, self.get_payload(parent_node_id, i - 1)?)?;
+        }
+        for i in self.number_of_children(parent_node_id)?..(child_idx + 1) {
+            self.set_child_node(
+                parent_node_id,
+                i,
+                self.get_child_node(parent_node_id, i - 1)?,
+            )?;
+        }
+
+        // Insert the new child entry, the key and the payload into the parent node
+        self.set_key(parent_node_id, child_idx, &split_key)?;
+        self.set_payload(parent_node_id, child_idx, split_payload)?;
+        self.set_child_node(parent_node_id, child_idx + 1, new_node_id)?;
+
+        Ok((existing_node, new_node_id))
+    }
+    fn split_off(&mut self, source_node_id: u64, split_at: usize) -> Result<u64> {
+        let n = self.number_of_keys(source_node_id)?;
+        if split_at < n {
+            // Allocate a new node
+            let target_node_id = self.allocate_new_node()?;
+
+            // Copy the right half of the keys, payload and child nodes to the new node
+            for i in split_at..n {
+                self.set_key(
+                    target_node_id,
+                    i - split_at,
+                    self.get_key(source_node_id, i)?.as_ref(),
+                )?;
+                self.set_payload(
+                    target_node_id,
+                    i - split_at,
+                    self.get_payload(source_node_id, i)?,
+                )?;
+            }
+            if !self.is_leaf(source_node_id)? {
+                for i in split_at..self.number_of_children(source_node_id)? {
+                    self.set_child_node(
+                        target_node_id,
+                        i - split_at,
+                        self.get_child_node(source_node_id, i)?,
+                    )?;
+                }
+            }
+
+            // Clip the size of keys in the source node
+            let mut source_node_view = self.get_mut(source_node_id)?;
+            source_node_view.num_keys_mut().write(split_at.try_into()?);
+            Ok(target_node_id)
+        } else {
+            Err(Error::KeyIndexOutOfBounds {
+                idx: split_at,
+                len: n,
+            })
+        }
     }
 
     fn get<'a>(&'a self, node_id: u64) -> Result<node::View<&[u8]>> {
@@ -109,27 +507,6 @@ where K: Serialize + DeserializeOwned + Clone {
         let offset: usize = NODE_BLOCK_ALIGNED_SIZE * node_id;
         let view = node::View::new(&mut self.mmap[offset..(offset + NODE_BLOCK_SIZE)]);
         Ok(view)
-    }
-
-
-    /// Allocate a new node.
-    ///
-    /// Returns the ID of the new node.
-    pub fn allocate_new_node(&mut self) -> Result<u64> {
-        // Make sure we still have enough space left
-        let new_offset = self.free_space_offset + NODE_BLOCK_ALIGNED_SIZE;
-        self.grow(new_offset)?;
-
-        // Return the old start of free space as block index
-        let result: u64 = (self.free_space_offset / NODE_BLOCK_ALIGNED_SIZE).try_into()?;
-
-        // Initialize some of the values
-        self.get_mut(result)?.num_keys_mut().write(0);
-        self.get_mut(result)?.is_leaf_mut().write(1);
-
-        // The next free block can be added after this block
-        self.free_space_offset = new_offset;
-        Ok(result)
     }
 
     /// Grows the file to contain at least the requested number of bytes.

--- a/src/btree/node.rs
+++ b/src/btree/node.rs
@@ -111,13 +111,11 @@ where K: Serialize + DeserializeOwned + Clone {
         Ok(view)
     }
 
-    
-
 
     /// Allocate a new node.
     ///
     /// Returns the ID of the new node.
-    pub fn allocate_block(&mut self) -> Result<u64> {
+    pub fn allocate_new_node(&mut self) -> Result<u64> {
         // Make sure we still have enough space left
         let new_offset = self.free_space_offset + NODE_BLOCK_ALIGNED_SIZE;
         self.grow(new_offset)?;

--- a/src/btree/node/tests.rs
+++ b/src/btree/node/tests.rs
@@ -2,15 +2,15 @@ use super::*;
 
 #[test]
 fn allocate_nodes() {
-    let mut f : NodeFile<u64> = NodeFile::with_capacity(0, &BtreeConfig::default()).unwrap();
-    let n1 = f.allocate_block().unwrap();
-    let n2 = f.allocate_block().unwrap();
-    let n3 = f.allocate_block().unwrap();
+    let mut f: NodeFile<u64> = NodeFile::with_capacity(0, &BtreeConfig::default()).unwrap();
+    let n1 = f.allocate_new_node().unwrap();
+    let n2 = f.allocate_new_node().unwrap();
+    let n3 = f.allocate_new_node().unwrap();
 
     assert_eq!(0, n1);
     assert_eq!(1, n2);
     assert_eq!(2, n3);
 
-    assert_eq!(0, f.get_mut(n1).unwrap().num_keys().read());
-    assert_eq!(1, f.get_mut(n1).unwrap().is_leaf().read());
+    assert_eq!(0, f.number_of_keys(n1).unwrap());
+    assert_eq!(true, f.is_leaf(n1).unwrap());
 }

--- a/src/btree/node/tests.rs
+++ b/src/btree/node/tests.rs
@@ -1,0 +1,16 @@
+use super::*;
+
+#[test]
+fn allocate_nodes() {
+    let mut f : NodeFile<u64> = NodeFile::with_capacity(0, &BtreeConfig::default()).unwrap();
+    let n1 = f.allocate_block().unwrap();
+    let n2 = f.allocate_block().unwrap();
+    let n3 = f.allocate_block().unwrap();
+
+    assert_eq!(0, n1);
+    assert_eq!(1, n2);
+    assert_eq!(2, n3);
+
+    assert_eq!(0, f.get_mut(n1).unwrap().num_keys().read());
+    assert_eq!(1, f.get_mut(n1).unwrap().is_leaf().read());
+}

--- a/src/btree/tests.rs
+++ b/src/btree/tests.rs
@@ -116,6 +116,8 @@ fn insert_get_static_size() {
     assert_eq!(Some(42), t.insert(0, 100).unwrap());
     assert_eq!(Some(100), t.insert(0, 42).unwrap());
 
+    print_tree(&t).unwrap();
+
     for i in 1..nr_entries {
         assert_eq!(true, t.contains_key(&i).unwrap());
 

--- a/src/btree/tests.rs
+++ b/src/btree/tests.rs
@@ -35,7 +35,7 @@ where
     if nb.is_leaf() {
         // Only print the keys
         for i in 0..nb.keys.len() {
-            builder.add_leaf(&format!("{:?} ({}. key)", nb.keys[i].key, i));
+            builder.add_leaf(&format!("{:?} ({}. key)", nb.keys[i], i));
         }
     } else {
         // Print both the keys and the child nodes
@@ -47,7 +47,7 @@ where
                 builder.add_leaf(&format!("ERROR: no child at index {}", i));
             }
             if i < nb.keys.len() {
-                builder.add_leaf(&format!("{:?} ({}. key)", nb.keys[i].key, i));
+                builder.add_leaf(&format!("{:?} ({}. key)", nb.keys[i], i));
             } else if i < nb.child_nodes.len() - 1 {
                 builder.add_leaf(&format!("ERROR: no key at index {}", i));
             }

--- a/src/btree/tests.rs
+++ b/src/btree/tests.rs
@@ -277,6 +277,8 @@ fn sorted_iterator() {
 
     for a in 0..=255 {
         t.insert(vec![1, a], true).unwrap();
+        print_tree(&t).unwrap();
+        println!("--------------");
     }
     for a in 0..=255 {
         t.insert(vec![0, a], true).unwrap();

--- a/src/btree/tests.rs
+++ b/src/btree/tests.rs
@@ -25,7 +25,7 @@ where
     K: Serialize + DeserializeOwned + PartialOrd + Clone + Ord + Debug,
     V: Serialize + DeserializeOwned + Clone,
 {
-    let nb = t.keys.get(node)?;
+    let nb = t.node_key_blocks.get(node)?;
     let mut branch = builder.add_branch(&format!(
         "(node {} with {} keys and {} children)",
         nb.id,

--- a/src/error.rs
+++ b/src/error.rs
@@ -11,8 +11,10 @@ pub enum Error {
     ExistingBlockTooSmall { block_id: usize, needed: u64 },
     #[error("The order of the tree must be at least 2, but {0} was requested.")]
     OrderTooSmall(usize),
+    #[error("The order of the tree must is too large ({0} was requested).")]
+    OrderTooLarge(usize),
     #[error("Requested index {idx} is larger than the number of keys in the node ({len})")]
-    KeyIndexOutOfBounds { idx: usize, len: usize },
+    KeyIndexOutOfBounds { idx: usize, len: usize},
     #[error("When trying to insert a non-existing key, the found node block was internal and not a leaf node")]
     InsertFoundInternalNode,
     #[error("Splitting a node resulted in an empty child node.")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -11,6 +11,8 @@ pub enum Error {
     ExistingBlockTooSmall { block_id: usize, needed: u64 },
     #[error("The order of the tree must be at least 2, but {0} was requested.")]
     OrderTooSmall(usize),
+    #[error("Requested index {idx} is larger than the number of keys in the node ({len})")]
+    KeyIndexOutOfBounds { idx: usize, len: usize },
     #[error("When trying to insert a non-existing key, the found node block was internal and not a leaf node")]
     InsertFoundInternalNode,
     #[error("Splitting a node resulted in an empty child node.")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -14,7 +14,7 @@ pub enum Error {
     #[error("The order of the tree must is too large ({0} was requested).")]
     OrderTooLarge(usize),
     #[error("Requested index {idx} is larger than the number of keys in the node ({len})")]
-    KeyIndexOutOfBounds { idx: usize, len: usize},
+    KeyIndexOutOfBounds { idx: usize, len: usize },
     #[error("When trying to insert a non-existing key, the found node block was internal and not a leaf node")]
     InsertFoundInternalNode,
     #[error("Splitting a node resulted in an empty child node.")]

--- a/src/file.rs
+++ b/src/file.rs
@@ -6,7 +6,6 @@ use std::{
 };
 
 use crate::{error::Result, PAGE_SIZE};
-use binary_layout::{prelude::*, FieldView};
 use bincode::Options;
 use linked_hash_map::LinkedHashMap;
 use memmap2::{MmapMut, MmapOptions};
@@ -22,131 +21,8 @@ pub fn page_aligned_capacity(capacity: usize) -> usize {
     (num_full_pages * PAGE_SIZE) - BlockHeader::size()
 }
 
-// Defines a single BTree node with references to the actual values in a tuple file
-// This node can up to 1361 keys and 1362 child node references.
-define_layout!(node, LittleEndian, {
-    id: u64,
-    num_keys: u16,
-    is_leaf: u8,
-    keys: [u8; 10888],
-    payloads: [u8; 10888],
-    child_nodes: [u8; 10896],
-});
 
-const NODE_BLOCK_SIZE: usize = 4095;
-const NODE_BLOCK_ALIGNED_SIZE: usize = PAGE_SIZE;
 
-pub fn get_key(field: &FieldView<&[u8], node::keys>, i: u8) -> Result<u64> {
-    let offset: usize = (i as usize) * 8;
-    let result: u64 = u64::from_le_bytes(field.data()[offset..(offset + 8)].try_into()?);
-    Ok(result)
-}
-
-pub fn set_key(field: &mut FieldView<&mut [u8], node::keys>, i: u8, value: usize) {
-    let offset: usize = (i as usize) * 8;
-    let value = value.to_le_bytes();
-    field.data_mut()[offset..].copy_from_slice(&value);
-}
-
-pub fn get_payload(field: &FieldView<&[u8], node::payloads>, i: u8) -> Result<u64> {
-    let offset: usize = (i as usize) * 8;
-    let result: u64 = u64::from_le_bytes(field.data()[offset..(offset + 8)].try_into()?);
-    Ok(result)
-}
-
-pub fn set_payload(field: &mut FieldView<&mut [u8], node::payloads>, i: u8, value: usize) {
-    let offset: usize = (i as usize) * 8;
-    let value = value.to_le_bytes();
-    field.data_mut()[offset..].copy_from_slice(&value);
-}
-
-pub fn get_child_node(field: &FieldView<&[u8], node::child_nodes>, i: u8) -> Result<u64> {
-    let offset: usize = (i as usize) * 8;
-    let result: u64 = u64::from_le_bytes(field.data()[offset..(offset + 8)].try_into()?);
-    Ok(result)
-}
-
-pub fn set_child_node(field: &mut FieldView<&mut [u8], node::child_nodes>, i: u8, value: usize) {
-    let offset: usize = (i as usize) * 8;
-    let value = value.to_le_bytes();
-    field.data_mut()[offset..].copy_from_slice(&value);
-}
-
-pub struct NodeFile {
-    free_space_offset: usize,
-    mmap: MmapMut,
-}
-
-impl NodeFile {
-    pub fn with_capacity(capacity: usize) -> Result<NodeFile> {
-        // Create an anonymous memory mapped file with the capacity as size
-        let capacity = capacity.max(1);
-        let mmap = MmapOptions::new()
-            .stack()
-            .len(capacity * NODE_BLOCK_ALIGNED_SIZE)
-            .map_anon()?;
-
-        Ok(NodeFile {
-            mmap,
-            free_space_offset: 0,
-        })
-    }
-
-    pub fn get(&self, node_id: u64) -> Result<node::View<&[u8]>> {
-        let node_id: usize = node_id.try_into()?;
-        let offset: usize = NODE_BLOCK_ALIGNED_SIZE * node_id;
-        let view = node::View::new(&self.mmap[offset..(offset + NODE_BLOCK_SIZE)]);
-        Ok(view)
-    }
-
-    pub fn get_mut(&mut self, node_id: u64) -> Result<node::View<&mut [u8]>> {
-        let node_id: usize = node_id.try_into()?;
-        let offset: usize = NODE_BLOCK_ALIGNED_SIZE * node_id;
-        let view = node::View::new(&mut self.mmap[offset..(offset + NODE_BLOCK_SIZE)]);
-        Ok(view)
-    }
-
-    /// Allocate a new node.
-    ///
-    /// Returns the ID of the new node.
-    pub fn allocate_block(&mut self) -> Result<u64> {
-        // Make sure we still have enough space left
-        let new_offset = self.free_space_offset + NODE_BLOCK_ALIGNED_SIZE;
-        self.grow(new_offset)?;
-
-        // Return the old start of free space as block index
-        let result: u64 = (self.free_space_offset / NODE_BLOCK_ALIGNED_SIZE).try_into()?;
-
-        // Initialize some of the values
-        self.get_mut(result)?.num_keys_mut().write(0);
-        self.get_mut(result)?.is_leaf_mut().write(1);
-
-        // The next free block can be added after this block
-        self.free_space_offset = new_offset;
-        Ok(result)
-    }
-
-    /// Grows the file to contain at least the requested number of bytes.
-    /// This needs to copy all content into a new temporary file.
-    /// To avoid this costly operation, the file size is at least doubled.
-    fn grow(&mut self, requested_size: usize) -> Result<()> {
-        if requested_size <= self.mmap.len() {
-            // Still enough space, no action required
-            return Ok(());
-        }
-
-        // Create a new anonymous memory mapped the content is copied to.
-        // Allocate at least twice the old file size so we don't need to grow too often
-        let new_size = requested_size.max(self.mmap.len() * 2);
-        let mut new_mmap = MmapOptions::new().stack().len(new_size).map_anon()?;
-
-        // Copy all content from the old file into the new file
-        new_mmap[0..self.mmap.len()].copy_from_slice(&self.mmap);
-
-        self.mmap = new_mmap;
-        Ok(())
-    }
-}
 
 /// Representation of a header at the start of each block.
 ///

--- a/src/file.rs
+++ b/src/file.rs
@@ -21,9 +21,6 @@ pub fn page_aligned_capacity(capacity: usize) -> usize {
     (num_full_pages * PAGE_SIZE) - BlockHeader::size()
 }
 
-
-
-
 /// Representation of a header at the start of each block.
 ///
 /// When allocating new blocks, the size of this header is not included.

--- a/src/file.rs
+++ b/src/file.rs
@@ -81,7 +81,10 @@ impl NodeFile {
     pub fn with_capacity(capacity: usize) -> Result<NodeFile> {
         // Create an anonymous memory mapped file with the capacity as size
         let capacity = capacity.max(1);
-        let mmap = MmapOptions::new().stack().len(capacity).map_anon()?;
+        let mmap = MmapOptions::new()
+            .stack()
+            .len(capacity * NODE_BLOCK_ALIGNED_SIZE)
+            .map_anon()?;
 
         Ok(NodeFile {
             mmap,

--- a/src/file.rs
+++ b/src/file.rs
@@ -113,7 +113,7 @@ where
 
     fn get_cached_entry(&self, block_id: usize) -> Option<Arc<B>> {
         if let Ok(mut cache) = self.cache.try_lock() {
-            if let Some(b) = cache.get(&block_id).cloned() {
+            if let Some(b) = cache.remove(&block_id) {
                 // Mark the block as recently used by re-inserting it
                 cache.insert(block_id, b.clone());
                 return Some(b);

--- a/src/file/tests.rs
+++ b/src/file/tests.rs
@@ -1,22 +1,6 @@
-use crate::file::{BlockHeader, set_key};
+use crate::file::BlockHeader;
 
-use super::{TemporaryBlockFile, NodeFile};
-
-#[test]
-fn allocate_nodes() {
-    let mut f = NodeFile::with_capacity(0).unwrap();
-    let n1 = f.allocate_block().unwrap();
-    let n2 = f.allocate_block().unwrap();
-    let n3 = f.allocate_block().unwrap();
-
-    assert_eq!(0, n1);
-    assert_eq!(1, n2);
-    assert_eq!(2, n3);
-
-    assert_eq!(0, f.get_mut(n1).unwrap().num_keys().read());
-    assert_eq!(1, f.get_mut(n1).unwrap().is_leaf().read());
-
-}
+use super::TemporaryBlockFile;
 
 #[test]
 fn grow_mmap_from_zero_capacity() {

--- a/src/file/tests.rs
+++ b/src/file/tests.rs
@@ -1,0 +1,106 @@
+use crate::file::{BlockHeader, set_key};
+
+use super::{TemporaryBlockFile, NodeFile};
+
+#[test]
+fn allocate_nodes() {
+    let mut f = NodeFile::with_capacity(0).unwrap();
+    let n1 = f.allocate_block().unwrap();
+    let n2 = f.allocate_block().unwrap();
+    let n3 = f.allocate_block().unwrap();
+
+    assert_eq!(0, n1);
+    assert_eq!(1, n2);
+    assert_eq!(2, n3);
+
+    assert_eq!(0, f.get_mut(n1).unwrap().num_keys().read());
+    assert_eq!(1, f.get_mut(n1).unwrap().is_leaf().read());
+
+}
+
+#[test]
+fn grow_mmap_from_zero_capacity() {
+    // Create file with empty capacity
+    let mut m = TemporaryBlockFile::<u64>::with_capacity(0, 0).unwrap();
+    // The capacity must be at least one
+    assert_eq!(1, m.mmap.len());
+
+    // Needs to grow
+    m.grow(128).unwrap();
+    assert_eq!(128, m.mmap.len());
+    m.grow(4096).unwrap();
+    assert_eq!(4096, m.mmap.len());
+
+    // No growing necessar
+    m.grow(1024).unwrap();
+    assert_eq!(4096, m.mmap.len());
+
+    // Grow with double size
+    m.grow(8192).unwrap();
+    assert_eq!(8192, m.mmap.len());
+
+    // Grow with less than the double size still creates the double size
+    m.grow(9000).unwrap();
+    assert_eq!(16384, m.mmap.len());
+}
+
+#[test]
+fn grow_mmap_with_capacity() {
+    let mut m = TemporaryBlockFile::<u64>::with_capacity(4096, 0).unwrap();
+    assert_eq!(4096, m.mmap.len());
+
+    // Don't grow if not necessary
+    m.grow(128).unwrap();
+    assert_eq!(4096, m.mmap.len());
+    m.grow(4096).unwrap();
+    assert_eq!(4096, m.mmap.len());
+
+    // Grow with double size
+    m.grow(8192).unwrap();
+    assert_eq!(8192, m.mmap.len());
+
+    // Grow with less than the double size still creates the double size
+    m.grow(9000).unwrap();
+    assert_eq!(16384, m.mmap.len());
+}
+
+#[test]
+fn block_insert_get_update() {
+    let mut m = TemporaryBlockFile::<Vec<u64>>::with_capacity(128, 0).unwrap();
+    assert_eq!(128, m.mmap.len());
+
+    let mut b: Vec<u64> = std::iter::repeat(42).take(10).collect();
+    let idx = m.allocate_block(256 - BlockHeader::size()).unwrap();
+    // The block needs space for the data, but also for the header
+    assert_eq!(256, m.mmap.len());
+
+    // Insert the block as it is
+    assert_eq!(true, m.can_update(idx, &b).is_ok());
+    m.put(idx, &b).unwrap();
+
+    // Get and check it is still equal
+    let retrieved_block = m.get_owned(idx).unwrap();
+    assert_eq!(b, retrieved_block);
+
+    // The block should be able to hold a little bit more vector elements
+    for i in 1..20 {
+        b.push(i);
+    }
+    assert_eq!(true, m.can_update(idx, &b).is_ok());
+    m.put(idx, &b).unwrap();
+    let retrieved_block = m.get_owned(idx).unwrap();
+    assert_eq!(b, retrieved_block);
+
+    // We can't grow the block beyond the allocated limit
+    let mut large_block = b.clone();
+    for i in 1..300 {
+        large_block.push(i);
+    }
+    assert_eq!(false, m.can_update(idx, &large_block).unwrap().0);
+    // Check that we can still insert the block, but that the relocation table is updated
+    m.put(idx, &large_block).unwrap();
+    assert_eq!(1, m.relocated_blocks.len());
+    assert_eq!(true, m.relocated_blocks.contains_key(&idx));
+    // Get the block and check the new value is returned
+    assert_eq!(large_block, m.get_owned(idx).unwrap());
+}


### PR DESCRIPTION
More efficient insert operation by not serializing a vector of keys for the whole node. Instead, keys are treated like values and the B-Tree nodes only store references to them.