### PR TITLE
Create our own temporary files to map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Backward incompatible**: The maximum order of a B-Tree (as per its configuration) is now
   84. This is necessary, so a node block always fits inside a memory block. You can configure
   a smaller size, but with 84 the memory page is utilized fully.
+- Instead of anonymous memory mapped files, we create our own temporary files. 
+  The former ones might only be written out to swap, which is a problem on
+  systems with small swap sizes.
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ serde_derive = "1"
 bincode = "1.3"
 linked-hash-map = "0.5"
 binary-layout = "2.1"
+tempfile = "3.3"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,3 +45,8 @@ pub use error::Error;
 
 const KB: usize = 1 << 10;
 const PAGE_SIZE: usize = 4 * KB;
+
+fn create_mmap(length: usize) -> error::Result<memmap2::MmapMut> {
+    let result = memmap2::MmapOptions::new().len(length).map_anon()?;
+    Ok(result)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,11 +42,18 @@ mod file;
 
 pub use btree::{BtreeConfig, BtreeIndex};
 pub use error::Error;
+use memmap2::MmapMut;
 
 const KB: usize = 1 << 10;
 const PAGE_SIZE: usize = 4 * KB;
 
-fn create_mmap(length: usize) -> error::Result<memmap2::MmapMut> {
-    let result = memmap2::MmapOptions::new().len(length).map_anon()?;
-    Ok(result)
+fn create_mmap(capacity: usize) -> error::Result<MmapMut> {
+    let file = tempfile::tempfile()?;
+    if capacity > 0 {
+        file.set_len(capacity.try_into()?)?;
+    }
+
+    // Load this file as memory mapped file
+    let mmap = unsafe { MmapMut::map_mut(&file)? };
+    return Ok(mmap);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,5 +55,5 @@ fn create_mmap(capacity: usize) -> error::Result<MmapMut> {
 
     // Load this file as memory mapped file
     let mmap = unsafe { MmapMut::map_mut(&file)? };
-    return Ok(mmap);
+    Ok(mmap)
 }


### PR DESCRIPTION
Instead of anonymous memory mapped files, we create our own temporary files. 
The former ones might only be written out to swap, which is a problem on
systems with small swap sizes.